### PR TITLE
Add custom webservice calendar extension.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
@@ -8,15 +8,13 @@ class Webservice_tt_calendar_ext
     var $settings_exist = 'y';
     var $docs_url = '';
 
-    var $settings = array();
-
     /**
      * Webservice_tt_calendar_ext constructor.
      * @param array $settings
      */
     public function __construct(array $settings = null)
     {
-        $this->settings = $settings != null ? $settings : array();
+//        $this->settings = $settings != null ? $settings : array();
     }
 
     public function activate_extension()
@@ -25,7 +23,6 @@ class Webservice_tt_calendar_ext
             'class' => __CLASS__,
             'method' => 'webservice_entry_row',
             'hook' => 'webservice_entry_row',
-            'settings' => serialize($this->settings),
             'priority' => 10,
             'version' => $this->version,
             'enabled' => 'y'
@@ -57,6 +54,11 @@ class Webservice_tt_calendar_ext
         return true;
     }
 
+    public function disable_extension() {
+        ee()->db->where('class', __CLASS__);
+        ee()->db->delete('extensions');
+    }
+
     public function webservice_entry_row($data = null, $fields = array())
     {
         //loop over the fields to get the relationship or playa field
@@ -66,6 +68,7 @@ class Webservice_tt_calendar_ext
                     //is there data or is the field set
                     if (isset($data[$field_name]) && !empty($data[$field_name])) {
                         // FIXME: figure out where to get data for this... (thomasvandoren, 2016-03-12)
+                        $some_calendar_event_id = $data[$field_name];
                         $new_data = array("some_calendar" => $data[$field_name]);
                         $data[$field_name] = $new_data;
                     }

--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
@@ -5,7 +5,7 @@ class Webservice_tt_calendar_ext
     var $name = 'Webservice TT Calendar Extension';
     var $version = '1.0';
     var $description = '';
-    var $settings_exist = 'y';
+    var $settings_exist = 'n';
     var $docs_url = '';
 
     /**
@@ -14,7 +14,6 @@ class Webservice_tt_calendar_ext
      */
     public function __construct($settings = null)
     {
-//        $this->settings = $settings != null ? $settings : array();
     }
 
     public function activate_extension()

--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
@@ -1,0 +1,100 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Webservice_tt_calendar_ext
+{
+    var $name = 'Webservice TT Calendar Extension';
+    var $version = '1.0';
+    var $description = '';
+    var $settings_exist = 'y';
+    var $docs_url = '';
+
+    var $settings = array();
+
+    /**
+     * Webservice_tt_calendar_ext constructor.
+     * @param array $settings
+     */
+    public function __construct(array $settings = null)
+    {
+        $this->settings = $settings != null ? $settings : array();
+    }
+
+    public function activate_extension()
+    {
+        $data = array(
+            'class' => __CLASS__,
+            'method' => 'webservice_entry_row',
+            'hook' => 'webservice_entry_row',
+            'settings' => serialize($this->settings),
+            'priority' => 10,
+            'version' => $this->version,
+            'enabled' => 'y'
+        );
+
+        ee()->db->insert('extensions', $data);
+
+        return true;
+    }
+
+    public function update_extension($current = '')
+    {
+        if ($current == '' OR $current == $this->version)
+        {
+            return FALSE;
+        }
+
+        if ($current < '1.0')
+        {
+            // Update to version 1.0
+        }
+
+        ee()->db->where('class', __CLASS__);
+        ee()->db->update(
+            'extensions',
+            array('version' => $this->version)
+        );
+
+        return true;
+    }
+
+    public function webservice_entry_row($data = null, $fields = array())
+    {
+        //loop over the fields to get the relationship or playa field
+        if (!empty($fields)) {
+            foreach ($fields as $field_name => $field) {
+                if ($field['field_type'] == 'calendar') {
+                    //is there data or is the field set
+                    if (isset($data[$field_name]) && !empty($data[$field_name])) {
+                        // FIXME: figure out where to get data for this... (thomasvandoren, 2016-03-12)
+                        $new_data = array("some_calendar" => $data[$field_name]);
+                        $data[$field_name] = $new_data;
+                    }
+                } else if ($field['field_type'] == 'rel') {
+                    //is there data or is the field set
+                    if (isset($data[$field_name]) && !empty($data[$field_name])) {
+                        // FIXME: figure out where to get data for this... (thomasvandoren, 2016-03-12)
+                        $data[$field_name] = array("some_rel" => $data[$field_name]);
+                    }
+                } else if ($field['field_type'] == 'relationship' || $field['field_type'] == 'playa') {
+                    //is there data or is the field set
+                    if (isset($data[$field_name]) && !empty($data[$field_name])) {
+                        $new_data = array();
+
+                        //get for each item the data
+                        foreach ($data[$field_name] as $entry_data) {
+                            $new_data[] = ee()->webservice_lib->get_entry($entry_data['entry_id'], array('*'), true);
+                        }
+
+                        //assign the data back
+                        $data[$field_name] = $new_data;
+                    }
+                }
+            }
+        }
+        return $data;
+    }
+}
+
+
+/* End of file ext.webservice_tt_calendar.php */
+/* Location: ./webservice_tt_calendar/libraries/ext.webservice_tt_calendar.php */

--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/webservice_settings.json
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/webservice_settings.json
@@ -1,0 +1,10 @@
+{
+  "name" : "tt_calendar",
+  "label": "TT Calendar",
+  "version" : "1.0",
+  "auth": false,
+  "public": false,
+  "enabled": true,
+  "methods": [],
+  "test": {}
+}


### PR DESCRIPTION
The webservice TT calendar extension populates calendar and rel field data for
entries coming back from webservice requests. For example, searching for entry
with id `4004` previously had integers (as strings) for the
event_dates_and_options, event_venue, and event_organization fields in response
body. With this extension enabled, those fields now have fully populated data
from the calendar or related entry.