### PR TITLE
Populate proper urls for event image matrix.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
@@ -98,6 +98,17 @@ class Webservice_tt_calendar_ext
                             }
                         }
                     }
+                } else if ($field['field_type'] == 'matrix') {
+                    //is there data or is the field set
+                    if (isset($data[$field_name]) && !empty($data[$field_name])) {
+                        $image_array = $data[$field_name];
+
+                        foreach($image_array as $key => $row) {
+                            if (array_key_exists('image', $row)) {
+                                $data[$field_name][$key]['url'] = ee()->typography->parse_file_paths($row['image']);
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, webservice was not including a full url for images in a matrix like
those in event_images. Update it to include the full url, in addition to the
templated value.