### PR TITLE
Support using headers to pass in webservice data/auth key/value pairs.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
@@ -880,23 +880,20 @@ class Webservice_rest
      */
     protected function _parse_data_from_headers($vars = array())
     {
-        foreach ($_SERVER as $name => $value)
-        {
-            if (substr($name, 0, 5) == 'HTTP_')
-            {
-                $name = strtolower(str_replace('HTTP_', '', $name));
+        $request_headers = apache_request_headers();
 
-                //fetch auth values
-                if(substr($name, 0, 16) == 'webservice_auth_')
-                {
-                    $name = strtolower(str_replace('webservice_auth_', '', $name));
-                    $vars['auth'][$name] = $value;
-                }
-                else if(substr($name, 0, 16) == 'webservice_data_')
-                {
-                    $name = strtolower(str_replace('webservice_data_', '', $name));
-                    $vars['auth'][$name] = $value;
-                }
+        foreach ($request_headers as $name => $value)
+        {
+            //fetch auth values
+            if(substr($name, 0, 16) == 'webservice_auth_')
+            {
+                $name = strtolower(str_replace('webservice_auth_', '', $name));
+                $vars['auth'][$name] = $value;
+            }
+            else if(substr($name, 0, 16) == 'webservice_data_')
+            {
+                $name = strtolower(str_replace('webservice_data_', '', $name));
+                $vars['data'][$name] = $value;
             }
         }
 

--- a/ttadmin/expressionengine/third_party/webservice/mcp.webservice.php
+++ b/ttadmin/expressionengine/third_party/webservice/mcp.webservice.php
@@ -574,7 +574,7 @@ class Webservice_mcp {
 
 				$rows[] = array(
 					WEBSERVICE_MAP.'_log_id' => $val->log_id,
-					WEBSERVICE_MAP.'_time' => $val->time != '' ? date('%d-%m-%Y %g:%i:%s', $val->time) /* ee()->localize->format_date('%d-%m-%Y %g:%i:%s', $val->time, false) */ : '-',
+					WEBSERVICE_MAP.'_time' => $val->time != '' ? date('Y-m-d G:i:s O', $val->time) /* ee()->localize->format_date('%d-%m-%Y %g:%i:%s', $val->time, false) */ : '-',
 					WEBSERVICE_MAP.'_username' => $val->username,
 					WEBSERVICE_MAP.'_ip' => $val->ip,
 					WEBSERVICE_MAP.'_service' => $val->service,


### PR DESCRIPTION
This enables requests to specify headers like `webservice_data_start_date`,
which is equivalent to setting the query string parameter
`data[start_date]`. Similar headers are supported for auth,
i.e. `webservice_auth_session_id` header is equivalent to `auth[session_id]`
query string param.

Also, fix date formatting in webservice logs.