### PR TITLE
Support headers with hyphens.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
@@ -901,19 +901,22 @@ class Webservice_rest
     }
 
     private function _get_request_headers() {
+        $headers = null;
         if (function_exists('getallheaders')) {
-            return getallheaders();
-        }
-
-        $headers = array();
-        foreach ($_SERVER as $name => $value)
-        {
-            if (substr($name, 0, 5) == 'HTTP_')
-            {
-                $headers[str_replace(' ', '_', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            $headers = getallheaders();
+        } else {
+            $headers = array();
+            foreach ($_SERVER as $name => $value) {
+                if (substr($name, 0, 5) == 'HTTP_') {
+                    $headers[ucwords(strtolower(str_replace('-', '_', substr($name, 5))))] = $value;
+                }
             }
         }
-        return $headers;
+        $canonical_headers = array();
+        foreach ($headers as $key => $value) {
+            $canonical_headers[str_replace('-', '_', strtolower($key))] = $value;
+        }
+        return $canonical_headers;
     }
 
 }

--- a/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
@@ -910,7 +910,7 @@ class Webservice_rest
         {
             if (substr($name, 0, 5) == 'HTTP_')
             {
-                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+                $headers[str_replace(' ', '_', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
             }
         }
         return $headers;

--- a/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/services/webservice_rest.php
@@ -880,7 +880,7 @@ class Webservice_rest
      */
     protected function _parse_data_from_headers($vars = array())
     {
-        $request_headers = apache_request_headers();
+        $request_headers = $this->_get_request_headers();
 
         foreach ($request_headers as $name => $value)
         {
@@ -900,6 +900,21 @@ class Webservice_rest
         return $vars;
     }
 
+    private function _get_request_headers() {
+        if (function_exists('getallheaders')) {
+            return getallheaders();
+        }
+
+        $headers = array();
+        foreach ($_SERVER as $name => $value)
+        {
+            if (substr($name, 0, 5) == 'HTTP_')
+            {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+        }
+        return $headers;
+    }
 
 }
 /* End of file webservice_rest.php */


### PR DESCRIPTION
Degrade nicely when getallheaders() function is not available. The newer
getallheaders() seems to support headers with underscores, but that does not
work with $_SERVER variable. $_SERVER only seems to recognize headers with
hyphens. So, deal with both hyphens and underscores.