### PR TITLE
Support read/create/delete favorites API.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice/libraries/webservice_base_api.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/webservice_base_api.php
@@ -193,10 +193,12 @@ class Webservice_base_api
 			}	
 		}
 
+		$tt_is_authed = ee()->webservice_lib->tt_favorites_api_and_is_member($method, ee()->session->userdata('member_id'));
+
 		/** ---------------------------------------
 		/**  (1) Service check, is the services active
 		/** ---------------------------------------*/
-		if(ee()->webservice_lib->has_free_access($method, ee()->session->userdata('username')) != 1)
+		if(!$tt_is_authed && ee()->webservice_lib->has_free_access($method, ee()->session->userdata('username')) != 1)
 		{	
 			if( (!isset($this->servicedata->active) || ! $this->servicedata->active) && $this->servicedata->admin == false )
 			{
@@ -211,7 +213,7 @@ class Webservice_base_api
 		/** ---------------------------------------
 		/**  (2) Service check, is the services selected (check by uri)
 		/** ---------------------------------------*/
-		if(ee()->webservice_lib->has_free_access($method, ee()->session->userdata('username')) != 1)
+		if(!$tt_is_authed && ee()->webservice_lib->has_free_access($method, ee()->session->userdata('username')) != 1)
 		{	
 			if( ( (@stripos($this->servicedata->services, ee()->uri->segment(2)) === false) && (@stripos($this->servicedata->services, ee()->session->cache[WEBSERVICE_MAP]['API']) === false))  && $this->servicedata->admin == false)
 			//if( (@stripos($this->servicedata->services, ee()->uri->segment(2)) === false)  && $this->servicedata->admin == false)
@@ -240,7 +242,7 @@ class Webservice_base_api
 		/** ---------------------------------------
 		/**  API check, runs this api for this server
 		/** ---------------------------------------*/
-		if(ee()->webservice_lib->has_free_access($method, ee()->session->userdata('username')) != 1)
+		if(!$tt_is_authed && ee()->webservice_lib->has_free_access($method, ee()->session->userdata('username')) != 1)
 		{
 			if( (@stripos($this->servicedata->apis, $this->api_type) === false)  && $this->servicedata->admin == false)
 			{

--- a/ttadmin/expressionengine/third_party/webservice/libraries/webservice_lib.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/webservice_lib.php
@@ -102,6 +102,15 @@ class Webservice_lib
 		return 0;
     }
 
+	public function tt_favorites_api_and_is_member($method = '', $member_id = '') {
+		return strlen($member_id) > 0 && ($this->tt_ends_with($method, 'favorites') || $this->tt_ends_with($method, 'favorite'));
+	}
+
+	private function tt_ends_with($haystack, $needle) {
+		// search forward starting from end minus needle length characters
+		return $needle === "" || (($temp = strlen($haystack) - strlen($needle)) >= 0 && strpos($haystack, $needle, $temp) !== false);
+	}
+
     // --------------------------------------------------------------------
         
     /**

--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/libraries/webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/libraries/webservice_tt_calendar.php
@@ -172,6 +172,8 @@ class Webservice_tt_calendar extends Module_builder_calendar
             /** ---------------------------------------*/
             $entry_ids = array_keys($return_entry_data['events']);
 
+            // FIXME: ensure $return_entry_data['events'] is always an object, even if empty, in json response. Same for $return_entry_data['dates']. (thomasvandoren, 2016-05-21)
+
             /** ---------------------------------------
             /** return response
             /** ---------------------------------------*/

--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/libraries/webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/libraries/webservice_tt_calendar.php
@@ -172,7 +172,13 @@ class Webservice_tt_calendar extends Module_builder_calendar
             /** ---------------------------------------*/
             $entry_ids = array_keys($return_entry_data['events']);
 
-            // FIXME: ensure $return_entry_data['events'] is always an object, even if empty, in json response. Same for $return_entry_data['dates']. (thomasvandoren, 2016-05-21)
+            // Make sure that we always return an object here, even if it is empty.
+            if (count($return_entry_data['events']) == 0) {
+                $return_entry_data['events'] = new stdClass();
+            }
+            if (count($return_entry_data['dates']) == 0) {
+                $return_entry_data['dates'] = new stdClass();
+            }
 
             /** ---------------------------------------
             /** return response

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
@@ -246,15 +246,10 @@ class Webservice_tt_favorites extends Module_builder_favorites
             // -------------------------------------------
 
             /** ---------------------------------------
-            /** Lets collect all the entry_ids so we can return
-            /** ---------------------------------------*/
-            $entry_ids = array_keys($entry_id_to_favorite);
-
-            /** ---------------------------------------
             /** return response
             /** ---------------------------------------*/
             $this->service_error['success_read']['metadata'] = array(
-                'id' => implode('|', $entry_ids),
+                'id' => $entry_id_to_favorite,
                 'limit' => $this->limit,
                 'offset' => $this->offset,
                 'total_results' => $this->total_results,
@@ -338,15 +333,10 @@ class Webservice_tt_favorites extends Module_builder_favorites
             // -------------------------------------------
 
             /** ---------------------------------------
-            /** Lets collect all the entry_ids so we can return
-            /** ---------------------------------------*/
-            $entry_ids = array_keys($entry_id_to_delete);
-
-            /** ---------------------------------------
             /** return response
             /** ---------------------------------------*/
             $this->service_error['success_read']['metadata'] = array(
-                'id' => implode('|', $entry_ids),
+                'id' => $entry_id_to_delete,
                 'limit' => $this->limit,
                 'offset' => $this->offset,
                 'total_results' => $this->total_results,

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
@@ -77,7 +77,7 @@ class Webservice_tt_favorites extends Module_builder_favorites
 
         $favorite_events = $this->_get_favorites($member_id, $site_id);
 
-        if(!$favorite_events || !is_array($favorite_events))
+        if(!is_array($favorite_events))
         {
             /** ---------------------------------------
             /** return response

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
@@ -158,6 +158,11 @@ class Webservice_tt_favorites extends Module_builder_favorites
             /** ---------------------------------------*/
             $entry_ids = array_keys($return_entry_data);
 
+            // Make sure that we always return an object here, even if it is empty.
+            if (count($return_entry_data) == 0) {
+                $return_entry_data = new stdClass();
+            }
+
             /** ---------------------------------------
             /** return response
             /** ---------------------------------------*/

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
@@ -212,7 +212,7 @@ class Webservice_tt_favorites extends Module_builder_favorites
         $member_id = ee()->session->userdata['member_id'];
 
         $entry_id_to_favorite = null;
-        if (!array_key_exists('entry_id', $post_data)) {
+        if (array_key_exists('entry_id', $post_data)) {
             $entry_id_to_favorite = $post_data['entry_id'];
         }
         $saved_event = $this->_create_favorite($member_id, $entry_id_to_favorite, $site_id);
@@ -304,7 +304,7 @@ class Webservice_tt_favorites extends Module_builder_favorites
         $member_id = ee()->session->userdata['member_id'];
 
         $entry_id_to_delete = null;
-        if (!array_key_exists('entry_id', $post_data)) {
+        if (array_key_exists('entry_id', $post_data)) {
             $entry_id_to_delete = $post_data['entry_id'];
         }
         $deleted_event = $this->_delete_favorite($member_id, $entry_id_to_delete, $site_id);

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
@@ -1,0 +1,267 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/**
+ * TeenTix favorites api
+ *
+ * @package		FIXME
+ * @category	Modules
+ * @author		FIXME
+ * @link		FIXME
+ * @license  	FIXME
+ * @copyright 	Copyright (c) 2016 FIXME
+ */
+
+/**
+ * Include the config file
+ */
+require_once PATH_THIRD.'webservice/config.php';
+
+if (! class_exists('Module_build_favorites')) {
+    require_once PATH_THIRD.'favorites/addon_builder/module_builder.php';
+}
+
+if (! class_exists('Favorites')) {
+    require_once PATH_THIRD.'favorites/mod.favorites.php';
+}
+
+
+class Webservice_tt_favorites extends Module_builder_favorites
+{
+    public $limit;
+    public $offset;
+    public $total_results;
+    public $absolute_results;
+
+    public function __construct()
+    {
+        parent::__construct('favorites');
+        ee()->load->library('api/entry/fieldtypes/webservice_fieldtype');
+    }
+
+    public function read_favorites($post_data = array()) {
+        $post_data = Webservice_helper::add_hook('read_favorites_start', $post_data);
+
+        /** ---------------------------------------
+        /**  Validate data
+        /** ---------------------------------------*/
+        $data_errors = array();
+
+        /** ---------------------------------------
+        /**  Set the site_id is empty
+        /** ---------------------------------------*/
+        if(!isset($post_data['site_id']) || $post_data['site_id'] == '') {
+            $post_data['site_id'] = 1;
+        }
+
+        /** ---------------------------------------
+        /**  Set the show_fields param
+        /** ---------------------------------------*/
+        if(!isset($post_data['output_fields']) || $post_data['output_fields'] == '') {
+            $post_data['output_fields'] = array();
+        }
+        else
+        {
+            $post_data['output_fields'] = explode("|", $post_data['output_fields']);
+        }
+
+        //save it to the cache
+        ee()->session->set_cache('webservice', 'output_fields', $post_data['output_fields']);
+
+        /** ---------------------------------------
+        /**  Get the fields
+        /** ---------------------------------------*/
+        $this->fields = $this->_get_fieldtypes();
+        
+        $member_id = ee()->session->userdata['member_id'];
+
+        $favorite_events = $this->_get_favorites($member_id);
+
+        if(!$favorite_events || !is_array($favorite_events))
+        {
+            /** ---------------------------------------
+            /** return response
+            /** ---------------------------------------*/
+            if(!$favorite_events)
+            {
+                return array(
+                    'message' => 'No Entry found'
+                );
+            }
+            else
+            {
+                return array(
+                    'message' => 'The following fields are not filled in: '.$favorite_events
+                );
+            }
+        }
+        else
+        {
+            $return_entry_data = array();
+
+            foreach($favorite_events as $entry_id)
+            {
+                /** ---------------------------------------
+                /**  get the entry data and check if the entry exists
+                /**  Also get the "categories" and preform the ee()->webservice_fieldtype->pre_process() call
+                /** ---------------------------------------*/
+                $entry_data = ee()->webservice_lib->get_entry($entry_id, array('*'), true);
+
+//				/** ---------------------------------------
+//				/** Get the categories
+//				/** ---------------------------------------*/
+//				$entry_data['categories'] = (ee()->webservice_category_model->get_entry_categories(array($entry_data['entry_id'])));
+//
+//				/** ---------------------------------------
+//				/**  Process the data per field
+//				/** ---------------------------------------*/
+//				if(!empty($this->fields))
+//				{
+//					foreach($this->fields as $key=>$val)
+//					{
+//						if(isset($entry_data[$val['field_name']]))
+//						{
+//							$entry_data[$val['field_name']] = ee()->webservice_fieldtype->pre_process($entry_data[$val['field_name']], $val['field_type'], $val['field_name'], $val, null, 'search_entry', $entry_id);
+//						}
+//					}
+//				}
+
+
+                /* -------------------------------------------
+                /* 'webservice_search_entry_end' hook.
+                /*  - Added: 3.2
+                */
+                $entry_data = Webservice_helper::add_hook('read_favorites_per_entry', $entry_data, false, $this->fields);
+                // -------------------------------------------
+
+                /* -------------------------------------------
+                /* 'webservice_entry_row' hook.
+                /*  - Added: 3.5
+                */
+                $entry_data = Webservice_helper::add_hook('entry_row', $entry_data, false, $this->fields);
+                // -------------------------------------------
+
+                //assign the data to the array
+                $return_entry_data[$entry_id] = $entry_data;
+
+            };
+
+            /* -------------------------------------------
+            /* 'webservice_search_entry_end' hook.
+            /*  - Added: 2.2
+            */
+            $return_entry_data = Webservice_helper::add_hook('read_favorites_end', $return_entry_data, false, $post_data);
+            // -------------------------------------------
+
+            /** ---------------------------------------
+            /** Lets collect all the entry_ids so we can return
+            /** ---------------------------------------*/
+            $entry_ids = array_keys($return_entry_data);
+
+            /** ---------------------------------------
+            /** return response
+            /** ---------------------------------------*/
+            $this->service_error['success_read']['metadata'] = array(
+                'id' => implode('|', $entry_ids),
+                'limit' => $this->limit,
+                'offset' => $this->offset,
+                'total_results' => $this->total_results,
+                'absolute_results' => $this->absolute_results
+            );
+            $this->service_error['success_read']['success'] = true;
+            $this->service_error['success_read']['data'] = $return_entry_data;
+            return $this->service_error['success_read'];
+        }
+    }
+
+    private function _get_favorites($member_id) {
+        $db = ee()->db;
+
+        $db->select('entry_id')->from('exp_favorites');
+        $db->where('member_id', $member_id);
+        // TODO: should this check site_id, channel_id? (thomasvandoren, 2016-05-19)
+        $query = $db->get();
+        
+        $row_count = $query->num_rows();
+        $event_ids = array();
+        if ($row_count > 0) {
+            foreach ($query->result_array() as $key => $row) {
+                $event_ids[] = $row['entry_id'];
+            }
+        }
+        return $event_ids;
+    }
+//
+//    // FIXME: implement me! (thomasvandoren, 2016-04-02)
+//    private function _get_events_in_range($start_date_str, $days_str) {
+//        if ($start_date_str == null || $days_str == null) {
+//            return '"start_date" and "days"';
+//        }
+//        $start_date = new DateTime($start_date_str, new DateTimeZone('UTC'));
+//        $days = new DateInterval('P'.$days_str.'D');
+//        $last_date = new DateTime($start_date_str, new DateTimeZone('UTC'));
+//        $last_date->add($days);
+//
+//        $db = ee()->db;
+//
+//        $db_start_date = $db->escape($start_date->format('Ymd'));
+//        $db_last_date = $db->escape($last_date->format('Ymd'));
+//
+//        // TODO: See Calendar_data()->fetch_event_ids() !!! (thomasvandoren, 2016-04-12)
+//
+//        $db->select('entry_id')->from('exp_calendar_events');
+//        $where = '(last_date = 0 AND start_date >= '.$db_start_date.' AND start_date <='.$db_last_date.') OR '.
+//            '(start_date <= '.$db_last_date.' AND last_date >= '.$db_start_date.') OR '.
+//            '(last_date >= '.$db_start_date.' AND start_date <= '.$db_last_date.')';
+//        $db->where($where);
+//        $query = $db->get();
+//
+//        $row_count = $query->num_rows();
+//        $event_ids = array();
+//        if ($row_count > 0) {
+//            foreach ($query->result_array() as $key => $row) {
+//                $event_ids[] = $row['entry_id'];
+//            }
+//        }
+//
+//        $event_data = $this->data->fetch_all_event_data($event_ids);
+//
+//        $events = array();
+//        foreach ($event_data as $k => $edata) {
+//            $events[] = new Calendar_event($edata, $start_date->format('Ymd'), $last_date->format('Ymd'), 0);
+//        }
+//
+//        $dates = array();
+//        foreach ($events as $event) {
+//            foreach ($event->dates as $date => $time_array) {
+//                if (!array_key_exists($date, $dates)) {
+//                    $dates[$date] = array();
+//                }
+//
+//                $dates[$date][] = $event->default_data['entry_id'];
+//            }
+//        }
+//
+//        $results = array(
+//            'entry_ids' => $event_ids,
+//            'dates' => $dates,
+//        );
+//
+//        return $results;
+//    }
+
+    /**
+     * Search an entry based on the given values
+     *
+     * @access	public
+     * @param	parameter list
+     * @return	void
+     */
+    private function _get_fieldtypes()
+    {
+        $channel_id = isset($this->channel['channel_id']) ? $this->channel['channel_id'] : null ;
+        $channel_fields = ee()->channel_data->get_channel_fields($channel_id)->result_array();
+        $fields = ee()->channel_data->utility->reindex($channel_fields, 'field_name');
+        return $fields;
+    }
+
+}

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites_api_static.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites_api_static.php
@@ -1,0 +1,53 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/**
+ * Static TeenTix favorites API
+ *
+ * @package		FIXME
+ * @category	FIXME
+ * @author		FIXME
+ * @link		FIXME
+ * @license  	FIXME
+ * @copyright 	Copyright (c) 2016 FIXME
+ */
+
+/**
+ * Include the config file
+ */
+require_once PATH_THIRD.'webservice/config.php';
+
+class Webservice_tt_favorites_api_static
+{
+    static function read_favorites($data, $type = '') {
+        //load the api class
+        ee()->load->library('webservice_tt_favorites');
+
+        $return_data = ee()->webservice_tt_favorites->read_favorites($data);
+
+        return self::serialize_response($return_data, $type);
+    }
+
+    private static function serialize_response($return_data, $type) {
+        //var_dump($return_data);exit;
+        if($type == 'soap')
+        {
+            if(isset($return_data['data']))
+            {
+                $return_data['data'] = webservice_format_soap_data($return_data['data'], 'entry_list');
+            }
+            if(isset($return_data['metadata']))
+            {
+                $return_data['metadata'] = webservice_format_soap_data($return_data['metadata']);
+            }
+        }
+
+        //format the array, because we cannot do nested arrays
+        if($type != 'rest' && isset($return_data['data']))
+        {
+            $return_data['data'] = webservice_format_data($return_data['data'], $type);
+        }
+
+        //return result
+        return $return_data;
+    }
+}

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites_api_static.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites_api_static.php
@@ -21,9 +21,19 @@ class Webservice_tt_favorites_api_static
     static function read_favorites($data, $type = '') {
         //load the api class
         ee()->load->library('webservice_tt_favorites');
-
         $return_data = ee()->webservice_tt_favorites->read_favorites($data);
+        return self::serialize_response($return_data, $type);
+    }
 
+    static function create_favorite($data, $type = '') {
+        ee()->load->library('webservice_tt_favorites');
+        $return_data = ee()->webservice_tt_favorites->create_favorite($data);
+        return self::serialize_response($return_data, $type);
+    }
+
+    static function delete_favorite($data, $type = '') {
+        ee()->load->library('webservice_tt_favorites');
+        $return_data = ee()->webservice_tt_favorites->delete_favorite($data);
         return self::serialize_response($return_data, $type);
     }
 

--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/webservice_settings.json
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/webservice_settings.json
@@ -1,0 +1,48 @@
+{
+  "name" : "tt_favorites",
+  "label": "TT Favorites",
+  "version" : "1.0",
+  "auth": true,
+  "public": false,
+  "enabled": true,
+  "methods": [
+    {
+      "method": "read_favorites",
+      "name": "Read Favorites",
+      "cacheable": true,
+      "soap": [
+        {
+          "name": "data",
+          "type": "xsd:ObjectList"
+        },
+        {
+          "name": "id",
+          "type": "xsd:string"
+        }
+      ]
+    },
+    {
+      "method": "create_favorite",
+      "name": "Create Favorite",
+      "clear_cache": true,
+      "soap": [
+        {
+          "name": "id",
+          "type": "xsd:string"
+        }
+      ]
+    },
+    {
+      "method": "delete_favorite",
+      "name": "Delete Favorite",
+      "clear_cache": true,
+      "soap": [
+        {
+          "name": "id",
+          "type": "xsd:string"
+        }
+      ]
+    }
+  ],
+  "test": {}
+}


### PR DESCRIPTION
* `/webservice/rest/read_favorites` - returns all favorites for the current user
* `/webservice/rest/create_favorite?data[entry_id]=<entry_id>` - store entry with id `<entry_id>` as a favorite for current user
* `/webservice/rest/delete_favorite?data[entry_id]=<entry_id>` - remove entry with id `<entry_id>` as a favorite for current user