### PR TITLE
Include non-html versions of all html fields in webservice responses.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
@@ -145,6 +145,11 @@ class Webservice_tt_calendar_ext
                 if ($field_name == 'event_featured_image' && array_key_exists($field_name, $data) && $data[$field_name] == false) {
                     $data[$field_name] = null;
                 }
+
+                if ($field['field_type'] == 'wygwam' && array_key_exists($field_name, $data) && !empty($data[$field_name])) {
+                    $orig = $data[$field_name];
+                    $data[$field_name.'_plain'] = strip_tags($orig);
+                }
             }
         }
         return $data;

--- a/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_calendar/ext.webservice_tt_calendar.php
@@ -122,7 +122,7 @@ class Webservice_tt_calendar_ext
                                     }
                                 }
 
-                                $data[$field_name] = $new_data;
+                                $data[$field_name] = self::add_plain_fields_for_wygwam_fields($new_data, $fields);
                                 break; // in case there somehow is more than one row
                             }
                         }
@@ -145,14 +145,23 @@ class Webservice_tt_calendar_ext
                 if ($field_name == 'event_featured_image' && array_key_exists($field_name, $data) && $data[$field_name] == false) {
                     $data[$field_name] = null;
                 }
+            }
+        }
+        $data = self::add_plain_fields_for_wygwam_fields($data, $fields);
+        return $data;
+    }
 
-                if ($field['field_type'] == 'wygwam' && array_key_exists($field_name, $data) && !empty($data[$field_name])) {
-                    $orig = $data[$field_name];
-                    $data[$field_name.'_plain'] = strip_tags($orig);
+    private static function add_plain_fields_for_wygwam_fields($d, $fields = array()) {
+        //loop over the fields to get the relationship or playa field
+        if (!empty($fields)) {
+            foreach ($fields as $field_name => $field) {
+                if ($field['field_type'] == 'wygwam' && array_key_exists($field_name, $d) && !empty($d[$field_name])) {
+                    $orig = $d[$field_name];
+                    $d[$field_name . '_plain'] = strip_tags($orig);
                 }
             }
         }
-        return $data;
+        return $d;
     }
 
     public function webservice_search_entry_end($data = null, $fields = array())


### PR DESCRIPTION
Previously, a field like `event_description` included html tags. There is
no easy way to remove all those html tags on the mobile clients. Update the
webservice response serializer to add additional fields with all tags
removed for all wygwam fields. The new fields are suffixed with `_plain`.
For example, responses will still have `event_description` with the html in
addition to the new `event_description_plain` field that has all the html
removed.