### PR TITLE
Fix login failure response.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice/libraries/webservice_base_api.php
+++ b/ttadmin/expressionengine/third_party/webservice/libraries/webservice_base_api.php
@@ -285,7 +285,8 @@ class Webservice_base_api
 			$res_auth = $this->auth_data = $this->base_authenticate_username($auth['username'], $auth['password']);
 
 			//is response false?
-			if(!$res_auth['success'])
+			if((array_key_exists('success', $res_auth) && !$res_auth['success']) ||
+				(array_key_exists('succes', $res_auth) && !$res_auth['succes']))
 			{
 				$this->error_str = $res_auth['message'];
 				return false;
@@ -519,14 +520,18 @@ class Webservice_base_api
 		//no username
 		if(empty($username))
 		{
-			return $this->service_error['error_auth'];
+			$response = $this->service_error['error_auth'];
+			$response['success'] = false;
+			return $response;
 		}
 
 		// get member id
         $query = ee()->db->get_where('members', array('username' => $username));
         if ($query == false || $query->num_rows() == 0)
         {
-        	return $this->service_error['error_auth'];
+        	$response = $this->service_error['error_auth'];
+			$response['success'] = false;
+			return $response;
         }
 
         $row = $query->row();


### PR DESCRIPTION
Previously, PHP errors were thrown when a user trying to login did not exist in
the database. The errors were returned as HTML snippets in the response. The
specific errors were a missing key (`success` or `succes`) in an array.

Update the webservice auth code to return an array with the `success` parameter
set to false when the username provided cannot be found in the databse.