### PR TITLE
Share sanitization code between calendar and favorites extensions.

### DIFF
--- a/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
+++ b/ttadmin/expressionengine/third_party/webservice_tt_favorites/libraries/webservice_tt_favorites.php
@@ -24,6 +24,10 @@ if (! class_exists('Favorites')) {
     require_once PATH_THIRD.'favorites/mod.favorites.php';
 }
 
+if (! class_exists('Webservice_tt_calendar_ext')) {
+    require_once PATH_THIRD.'webservice_tt_calendar/ext.webservice_tt_calendar.php';
+}
+
 
 class Webservice_tt_favorites extends Module_builder_favorites
 {
@@ -125,6 +129,8 @@ class Webservice_tt_favorites extends Module_builder_favorites
 //						}
 //					}
 //				}
+
+                Webservice_tt_calendar_ext::sanitize_single_entry($entry_data);
 
 
                 /* -------------------------------------------


### PR DESCRIPTION
Previously, events without event organizations set the event_organization
property to `"0"` in the read_favorites API. Update the favorites logic to
sanitize entries in the same way we do for calendar event (i.e. set these 0
values to null).

Fix several array checks along the way.