### PR TITLE
Disable address verification, temporarily.

### DIFF
--- a/ttadmin/expressionengine/third_party/freeform_tt_address_validation/ext.freeform_tt_address_validation.php
+++ b/ttadmin/expressionengine/third_party/freeform_tt_address_validation/ext.freeform_tt_address_validation.php
@@ -118,7 +118,10 @@ If you experience any issues, or if you keep getting redirected to this error pa
 
     private function verify_address($addr_info) {
         // Do not try to verify international addresses.
-        if ($addr_info['address_country'] != 'US') {
+	// FIXME: temp fix to disable lob verification until we can really fix.
+	//        50% of addresses are currently failing, which is not good.
+	//        (thomasvandoren, 2017-12-10)
+        if (true || $addr_info['address_country'] != 'US') {
             return array(
                 'address' => array_merge(
                     array(


### PR DESCRIPTION
A lot of valid addresses are failing address validation, which is
causing undue burden on teentix staff. Disable validation for now, and
I will investigate later this month.